### PR TITLE
Safer IO

### DIFF
--- a/lib/presso.rb
+++ b/lib/presso.rb
@@ -27,6 +27,7 @@ class Presso
           else
             raise PressoError, "File #{path} is not a regular file."
           end
+          stream.close_entry
         end
         stream_io.close
       end


### PR DESCRIPTION
In particular, it opens only one IO for the zipper stream, and keeps a reference to it throughout.

Upon GC, the temporary IOs would actually close the zip streams, which caused all kinds of problems.
