### PR TITLE
Ensure output files are closed in #unzip

### DIFF
--- a/lib/presso.rb
+++ b/lib/presso.rb
@@ -20,7 +20,9 @@ class Presso
         Dir['**/*'].each do |path|
           if File.file?(path)
             stream.put_next_entry(JavaUtilZip::ZipEntry.new(path))
-            IO.copy_stream(path, stream_io)
+            File.open(path) do |input|
+              IO.copy_stream(input, stream_io)
+            end
             stream_io.flush
           elsif File.directory?(path)
             stream.put_next_entry(JavaUtilZip::ZipEntry.new(path+'/'))

--- a/lib/presso.rb
+++ b/lib/presso.rb
@@ -46,7 +46,9 @@ class Presso
             FileUtils.mkdir_p(entry.name)
           else
             FileUtils.mkdir_p(File.dirname(entry.name))
-            IO.copy_stream(stream_io, entry.name)
+            File.open(entry.name, 'w') do |output|
+              IO.copy_stream(stream_io, output)
+            end
           end
           stream.close_entry
         end


### PR DESCRIPTION
After debugging an issue which I originally thought was related to Presso, me and @grddev realized that JRuby doesn't close the target file in IO.copy_stream when passed a path. At least not in JRuby 1.7.23. I don't know under which circumstances this could be an issue, but it should be better to close it than not to.