### PR TITLE
Add option to set an explicit compression level

### DIFF
--- a/lib/presso.rb
+++ b/lib/presso.rb
@@ -11,11 +11,14 @@ class Presso
 
   PressoError = Class.new(StandardError)
 
-  def zip_dir(output_path, input_directory)
+  def zip_dir(output_path, input_directory, options={})
     output_path = File.expand_path(output_path)
     Dir.chdir(input_directory) do
       File.open(output_path, File::WRONLY|File::CREAT|File::EXCL, binmode: true) do |file|
         stream = JavaUtilZip::ZipOutputStream.new(file.to_outputstream)
+        if (compression_level = options[:compression_level])
+          stream.level = compression_level
+        end
         stream_io = stream.to_io
         Dir['**/*'].each do |path|
           if File.file?(path)

--- a/spec/integration/presso_spec.rb
+++ b/spec/integration/presso_spec.rb
@@ -76,6 +76,22 @@ describe Presso do
         expect { subject.zip_dir('my.zip', dir_to_zip) }.to raise_error(Presso::PressoError, /not_a_file.*not a regular file/)
       end
     end
+
+    context 'when no compression level is provided' do
+      it 'uses the default compression level' do
+        subject.zip_dir('default.zip', dir_to_zip)
+        subject.zip_dir('level--1.zip', dir_to_zip, compression_level: -1)
+        expect(File.size('level--1.zip')).to eql(File.size('default.zip'))
+      end
+    end
+
+    context 'when a compression level is provided' do
+      it 'uses the provided compression level' do
+        subject.zip_dir('default.zip', dir_to_zip)
+        subject.zip_dir('level-0.zip', dir_to_zip, compression_level: 0)
+        expect(File.size('level-0.zip')).to be > File.size('default.zip')
+      end
+    end
   end
 
   describe '#unzip' do


### PR DESCRIPTION
This suggests adding a compression level option to `zip_dir`.

I was unsure how to test this feature. What I've done is to add integration tests which compares the size of files zipped using different compression levels. Other suggestions are welcome. :)
